### PR TITLE
Fixes issue where commenting adds a '\' before the '#'

### DIFF
--- a/Syntaxes/TOML.xml
+++ b/Syntaxes/TOML.xml
@@ -12,7 +12,7 @@
     
     <comments>
         <single>
-            <expression>\#</expression>
+            <expression>#</expression>
         </single>
     </comments>
     


### PR DESCRIPTION
The hash '#' symbol does not need to be escaped here.

Resolves #1 